### PR TITLE
fix: TypeError from scipy.optimize.fsolve on newer NumPy/SciPy

### DIFF
--- a/resemble_enhance/enhancer/lcfm/cfm.py
+++ b/resemble_enhance/enhancer/lcfm/cfm.py
@@ -70,7 +70,7 @@ class Solver:
             return (a**t - 1) / (a - 1)
 
         # Solve h(1/n) = 0.5
-        a = float(scipy.optimize.fsolve(lambda a: h(1 / n, a) - 0.5, x0=0))
+        a = float(scipy.optimize.fsolve(lambda a: h(1 / n, a) - 0.5, x0=0)[0])
 
         t = h(t, a=a)
 


### PR DESCRIPTION
`enhance()` crashes on NumPy 2.x / SciPy 1.14+ with:

    TypeError: only 0-dimensional arrays can be converted to Python scalars

at `resemble_enhance/enhancer/lcfm/cfm.py`, line 73.

## Cause

`scipy.optimize.fsolve` returns a 1-d ndarray (shape `(1,)`).

Older NumPy silently allowed `float(array_1d)`, but NumPy 2.0 deprecated this and later versions raise TypeError for non-0-d arrays.

## Fix

Extract the scalar with `[0]` before calling `float()`:

```python
a = float(scipy.optimize.fsolve(...)[0])
```

No change in behaviour on older versions - indexing a 1-element array has always returned a 0-d scalar.
