### PR TITLE
Fix fsolve usage, add torchcodec, ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 version.py
 __pycache__
 model_repo
+.DS_Store

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ tqdm>=4.66.1
 resampy>=0.4.2
 tabulate>=0.8.10
 gradio>=4.8.0
+torchcodec

--- a/resemble_enhance/enhancer/lcfm/cfm.py
+++ b/resemble_enhance/enhancer/lcfm/cfm.py
@@ -70,7 +70,8 @@ class Solver:
             return (a**t - 1) / (a - 1)
 
         # Solve h(1/n) = 0.5
-        a = float(scipy.optimize.fsolve(lambda a: h(1 / n, a) - 0.5, x0=0))
+        a = float(scipy.optimize.fsolve(lambda a: h(1 / n, a) - 0.5, x0=0)[0])
+        # Fixed scaler here for newer numpi
 
         t = h(t, a=a)
 


### PR DESCRIPTION
Python 3.14 and Numpy 2.0 compatibility fixes

I added the torchcodec dependency. When you run the old code on Python 3.14, it fails with a traceback stating that in order to use a torch feature you need torchcodec.

I added Numpy array handling within resemble_enhance/enhancer/lcfm/cfm.py to be compatible with newer Numpy versions. The older approach used deprecated NumPy behavior that breaks in future versions.

Tested in CPU mode on Python 3.14 and MacOS Tahoe on a Mac with M4 chip.